### PR TITLE
Add unit test to ensure octopus is generic

### DIFF
--- a/octopus/tests/test_genericness.py
+++ b/octopus/tests/test_genericness.py
@@ -3,5 +3,6 @@ from .. import models
 
 
 def test_whether_octopus_is_generic():
-    assert("Prior" not in dir(core))
-    assert("Likelihood" not in dir(core))
+    for bad_word in ["Prior", "Likelihood"]:
+        assert(bad_word not in dir(core))
+        assert(bad_word not in dir(models))

--- a/octopus/tests/test_genericness.py
+++ b/octopus/tests/test_genericness.py
@@ -4,5 +4,5 @@ from .. import models
 
 def test_whether_octopus_is_generic():
     for bad_word in ["Prior", "Likelihood"]:
-        assert(bad_word not in dir(core))
         assert(bad_word not in dir(models))
+        assert(bad_word not in dir(core))

--- a/octopus/tests/test_genericness.py
+++ b/octopus/tests/test_genericness.py
@@ -1,0 +1,7 @@
+from .. import core
+from .. import models
+
+
+def test_whether_octopus_is_generic():
+    assert("Prior" not in dir(core))
+    assert("Likelihood" not in dir(core))


### PR DESCRIPTION
This pull request ensures that octopus provides access to distributions in a generic way, whether or not they are priors or likelihoods or posteriors. :trollface: