### PR TITLE
Changed `self.prior` to `self.logprior` and transformed into PEP8

### DIFF
--- a/oktopus/likelihood.py
+++ b/oktopus/likelihood.py
@@ -43,9 +43,11 @@ class Likelihood(LossFunction):
 
     def jeffreys_prior(self, params):
         """
-        Computes the negative of the log of Jeffrey's prior and evaluates it at ``params``.
+        Computes the negative of the log of Jeffrey's prior
+            and evaluates it at ``params``.
         """
-        return - 0.5 * np.linalg.slogdet(self.fisher_information_matrix(params))[1]
+        jeffreys_prior_ = self.fisher_information_matrix(params)
+        return - 0.5 * np.linalg.slogdet(jeffreys_prior_)[1]
 
     @abstractmethod
     def evaluate(self, params):
@@ -120,7 +122,7 @@ class MultinomialLikelihood(Likelihood):
         self.mean = mean
 
     def __repr__(self):
-        return "<MultinomialLikelihood(mean={})>".format(self.mean)
+        return f"<MultinomialLikelihood(mean={self.mean})>"
 
     @property
     def n_counts(self):
@@ -137,7 +139,8 @@ class MultinomialLikelihood(Likelihood):
         fisher = np.empty(shape=(n_params, n_params))
 
         if not hasattr(self.mean, 'gradient'):
-            _grad = lambda mean, argnum, params: jacobian(mean, argnum=argnum)(*params)
+            _grad = lambda mean, argnum, params: jacobian(
+                mean, argnum=argnum)(*params)
         else:
             _grad = lambda mean, argnum, params: mean.gradient(*params)[argnum]
 
@@ -155,15 +158,18 @@ class MultinomialLikelihood(Likelihood):
         # use the gradient if the model provides it.
         # if not, compute it using autograd.
         if not hasattr(self.mean, 'gradient'):
-            _grad = lambda mean, argnum, params: jacobian(mean, argnum)(*params)
+            _grad = lambda mean, argnum, params: jacobian(
+                mean, argnum)(*params)
         else:
             _grad = lambda mean, argnum, params: mean.gradient(*params)[argnum]
         n_params = len(np.atleast_1d(params))
         grad_likelihood = np.array([])
         for i in range(n_params):
             grad = _grad(self.mean, i, params)
-            grad_likelihood = np.append(grad_likelihood,
-                                        - np.nansum(self.data * grad / self.mean(*params)))
+            grad_likelihood = np.append(
+                grad_likelihood,
+                -np.nansum(self.data * grad / self.mean(*params))
+            )
         return grad_likelihood
 
 
@@ -171,14 +177,15 @@ class PoissonLikelihood(Likelihood):
     r"""
     Implements the negative log likelihood function for independent
     (possibly non-identically) distributed Poisson measurements.
-    This class also contains a method to compute maximum likelihood estimators (MLE)
-    for the mean of the Poisson distribution.
+    This class also contains a method to compute maximum likelihood estimators 
+    (MLE) for the mean of the Poisson distribution.
 
     More precisely, the MLE is computed as:
 
     .. math::
 
-         \arg \min_{\theta \in \Theta} \sum_k \lambda_k(\theta) - y_k \cdot \log \lambda_k(\theta)
+         \arg \min_{\theta \in \Theta} \sum_k \lambda_k(\theta) 
+            - y_k \cdot \log \lambda_k(\theta)
 
     Attributes
     ----------
@@ -191,8 +198,9 @@ class PoissonLikelihood(Likelihood):
 
     Notes
     -----
-    See `here <https://mirca.github.io/geerts-conjecture/>`_ for the mathematical
-    derivation of the Poisson likelihood expression.
+    See `here <https://mirca.github.io/geerts-conjecture/>`_
+        for the mathematical derivation of the Poisson likelihood
+        expression.
 
     Examples
     --------
@@ -217,7 +225,9 @@ class PoissonLikelihood(Likelihood):
     >>> mean_unc = logL.uncertainties(mean_hat.x)
     >>> mean_unc
     array([ 3.04795015])
-    >>> print("{:.5f}".format(math.sqrt(np.mean(toy_data)))) # theorectical Fisher information
+
+    # theorectical Fisher information
+    >>> print("{:.5f}".format(math.sqrt(np.mean(toy_data))))
     3.04795
     """
 
@@ -226,17 +236,20 @@ class PoissonLikelihood(Likelihood):
         self.mean = mean
 
     def __repr__(self):
-        return "<PoissonLikelihood(mean={})>".format(self.mean)
+        return f"<PoissonLikelihood(mean={self.mean})>"
 
     def evaluate(self, params):
-        return np.nansum(self.mean(*params) - self.data * np.log(self.mean(*params)))
+        return np.nansum(
+            self.mean(*params) - self.data * np.log(self.mean(*params))
+        )
 
     def fisher_information_matrix(self, params):
         n_params = len(np.atleast_1d(params))
         fisher = np.empty(shape=(n_params, n_params))
 
         if not hasattr(self.mean, 'gradient'):
-            _grad = lambda mean, argnum, params: jacobian(mean, argnum=argnum)(*params)
+            _grad = lambda mean, argnum, params: jacobian(
+                mean, argnum=argnum)(*params)
         else:
             _grad = lambda mean, argnum, params: mean.gradient(*params)[argnum]
 
@@ -254,15 +267,18 @@ class PoissonLikelihood(Likelihood):
         # use the gradient if the model provides it.
         # if not, compute it using autograd.
         if not hasattr(self.mean, 'gradient'):
-            _grad = lambda mean, argnum, params: jacobian(mean, argnum)(*params)
+            _grad = lambda mean, argnum, params: jacobian(
+                mean, argnum)(*params)
         else:
             _grad = lambda mean, argnum, params: mean.gradient(*params)[argnum]
         n_params = len(np.atleast_1d(params))
         grad_likelihood = np.array([])
         for i in range(n_params):
             grad = _grad(self.mean, i, params)
-            grad_likelihood = np.append(grad_likelihood,
-                                        np.nansum(grad * (1 - self.data / self.mean(*params))))
+            grad_likelihood = np.append(
+                grad_likelihood,
+                np.nansum(grad * (1 - self.data / self.mean(*params)))
+            )
         return grad_likelihood
 
 
@@ -276,7 +292,8 @@ class GaussianLikelihood(Likelihood):
 
     .. math::
 
-         \arg \min_{\theta \in \Theta} \dfrac{1}{2}\sum_k \left(\dfrac{y_k - \mu_k(\theta)}{\sigma_k}\right)^2
+         \arg \min_{\theta \in \Theta} \dfrac{1}{2}\sum_k \left(\dfrac{y_k
+            - \mu_k(\theta)}{\sigma_k}\right)^2
 
     Attributes
     ----------
@@ -300,22 +317,29 @@ class GaussianLikelihood(Likelihood):
     >>> fake_data = x * 3 + 10 + np.random.normal(scale=2, size=x.shape)
     >>> def line(x, alpha, beta):
     ...     return alpha * x + beta
+
     >>> my_line = lambda a, b: line(x, a, b)
     >>> logL = GaussianLikelihood(fake_data, my_line, 4)
     >>> p0 = (1, 1) # dumb initial_guess for alpha and beta
     >>> p_hat = logL.fit(x0=p0, method='Nelder-Mead')
     >>> p_hat.x # fitted parameters
     array([  2.96263393,  10.32860717])
-    >>> p_hat_unc = logL.uncertainties(p_hat.x) # get uncertainties on fitted parameters
+
+    # get uncertainties on fitted parameters
+    >>> p_hat_unc = logL.uncertainties(p_hat.x) 
     >>> p_hat_unc
     array([ 0.04874546,  0.28178535])
+
     >>> plt.plot(x, fake_data, 'o') # doctest: +SKIP
     >>> plt.plot(x, line(*p_hat.x)) # doctest: +SKIP
     >>> # The exact values from linear algebra would be:
     >>> M = np.array([[np.sum(x * x), np.sum(x)], [np.sum(x), len(x)]])
-    >>> alpha, beta = np.dot(np.linalg.inv(M), np.array([np.sum(fake_data * x), np.sum(fake_data)]))
+    >>> alpha, beta = np.dot(np.linalg.inv(M),
+                             np.array([np.sum(fake_data * x),
+                                       np.sum(fake_data)]))
     >>> print(alpha)
     2.96264087528
+
     >>> print(beta)
     10.3286166099
     """
@@ -326,7 +350,7 @@ class GaussianLikelihood(Likelihood):
         self.var = var
 
     def __repr__(self):
-        return "<GaussianLikelihood(mean={}, var={})>".format(self.mean, self.var)
+        return f"<GaussianLikelihood(mean={self.mean}, var={self.var})>"
 
     def evaluate(self, params):
         r = self.data - self.mean(*params)
@@ -336,7 +360,8 @@ class GaussianLikelihood(Likelihood):
         # use the gradient if the model provides it.
         # if not, compute it using autograd.
         if not hasattr(self.mean, 'gradient'):
-            _grad = lambda mean, argnum, params: jacobian(mean, argnum)(*params)
+            _grad = lambda mean, argnum, params: jacobian(
+                mean, argnum)(*params)
         else:
             _grad = lambda mean, argnum, params: mean.gradient(*params)[argnum]
         n_params = len(np.atleast_1d(params))
@@ -361,7 +386,8 @@ class GaussianLikelihood(Likelihood):
         fisher = np.zeros(shape=(n_params, n_params))
 
         if not hasattr(self.mean, 'gradient'):
-            _grad = lambda mean, argnum, params: jacobian(mean, argnum=argnum)(*params)
+            _grad = lambda mean, argnum, params: jacobian(
+                mean, argnum=argnum)(*params)
         else:
             _grad = lambda mean, argnum, params: mean.gradient(*params)[argnum]
 
@@ -383,7 +409,8 @@ class LaplacianLikelihood(Likelihood):
 
     .. math::
 
-         \arg \min_{\theta \in \Theta} \sum_k \dfrac{|y_k - \mu_k(\theta)|}{\sigma_k}
+         \arg \min_{\theta \in \Theta} \sum_k \dfrac{|y_k
+            - \mu_k(\theta)|}{\sigma_k}
 
     Attributes
     ----------
@@ -401,10 +428,12 @@ class LaplacianLikelihood(Likelihood):
         self.var = var
 
     def __repr__(self):
-        return "<LaplacianLikelihood(mean={}, var={})>".format(self.mean, self.var)
+        return f"<LaplacianLikelihood(mean={self.mean}, var={self.var})>"
 
     def evaluate(self, params):
-        return np.nansum(np.abs(self.data - self.mean(*params)) / np.sqrt(.5 * self.var))
+        return np.nansum(
+            np.abs(self.data - self.mean(*params)) / np.sqrt(.5 * self.var)
+        )
 
     def fisher_information_matrix(self, params):
         raise NotImplementedError
@@ -440,7 +469,9 @@ class MultivariateGaussianLikelihood(Likelihood):
             self._cov_inv = np.linalg.inv(self.cov)
 
     def __repr__(self):
-        return "<MultivariateGaussianLikelihood(mean={}, cov={})>".format(self.mean, self.cov)
+        return (f"<MultivariateGaussianLikelihood("
+                f"mean={self.mean}, "
+                f"cov={self.cov})>")
 
     def evaluate(self, params):
         """
@@ -452,8 +483,8 @@ class MultivariateGaussianLikelihood(Likelihood):
             parameter vector of the mean model and covariance matrix
         """
         if callable(self.cov):
-            theta = params[:self.dim] # mean model parameters
-            alpha = params[self.dim:] # kernel parameters (hyperparameters)
+            theta = params[:self.dim]  # mean model parameters
+            alpha = params[self.dim:]  # kernel parameters (hyperparameters)
             mean = self.mean(*theta)
             cov = self.cov(*alpha)
             self._cov_inv = np.linalg.inv(cov)
@@ -470,7 +501,8 @@ class MultivariateGaussianLikelihood(Likelihood):
         # use the gradient if the model provides it.
         # if not, compute it using autograd.
         if not hasattr(self.mean, 'gradient'):
-            _grad = lambda mean, argnum, params: jacobian(mean, argnum)(*params)
+            _grad = lambda mean, argnum, params: jacobian(
+                mean, argnum)(*params)
         else:
             _grad = lambda mean, argnum, params: mean.gradient(*params)[argnum]
         n_params = len(np.atleast_1d(params))
@@ -487,7 +519,8 @@ class MultivariateGaussianLikelihood(Likelihood):
         fisher = np.zeros(shape=(n_params, n_params))
 
         if not hasattr(self.mean, 'gradient'):
-            _grad = lambda mean, argnum, params: jacobian(mean, argnum=argnum)(*params)
+            _grad = lambda mean, argnum, params: jacobian(
+                mean, argnum=argnum)(*params)
         else:
             _grad = lambda mean, argnum, params: mean.gradient(*params)[argnum]
 
@@ -495,7 +528,8 @@ class MultivariateGaussianLikelihood(Likelihood):
 
         for i in range(n_params):
             for j in range(i, n_params):
-                fisher[i, j] = np.nansum(grad_mean[i] * self._cov_inv * grad_mean[j])
+                fisher[i, j] = np.nansum(
+                    grad_mean[i] * self._cov_inv * grad_mean[j])
                 fisher[j, i] = fisher[i, j]
 
         return fisher
@@ -510,7 +544,9 @@ class BernoulliLikelihood(Likelihood):
     More precisely, the MLE is computed as
 
     .. math::
-        \arg \min_{\theta \in \Theta} - \sum_{i=1}^{n} y_i\log\pi_i(\mathbf{\theta}) + (1 - y_i)\log(1 - \pi_i(\mathbf{\theta}))
+        \arg \min_{\theta \in \Theta} - \sum_{i=1}^{n} 
+            y_i\log\pi_i(\mathbf{\theta}) + 
+            (1 - y_i)\log(1 - \pi_i(\mathbf{\theta}))
 
     Attributes
     ----------
@@ -524,25 +560,32 @@ class BernoulliLikelihood(Likelihood):
     >>> import numpy as np
     >>> from oktopus import BernoulliLikelihood, UniformPrior, Posterior
     >>> from oktopus.models import ConstantModel as constant
-    >>> # generate integer fake data in the set {0, 1}
+
+    # generate integer fake data in the set {0, 1}
     >>> np.random.seed(0)
     >>> y = np.random.choice([0, 1], size=401)
-    >>> # create a model
+
+    # create a model
     >>> p = constant()
-    >>> # perform optimization
+
+    # perform optimization
     >>> ber = BernoulliLikelihood(data=y, mean=p)
     >>> unif = UniformPrior(lb=0., ub=1.)
     >>> pp = Posterior(likelihood=ber, prior=unif)
     >>> result = pp.fit(x0=.3, method='powell')
-    >>> # get best fit parameters
+
+    # get best fit parameters
     >>> print(np.round(result.x, 3))
     0.529
+
     >>> print(np.round(np.mean(y>0), 3)) # theorectical MLE
     0.529
-    >>> # get uncertainties on the best fit parameters
+
+    # get uncertainties on the best fit parameters
     >>> print(ber.uncertainties([result.x]))
     [ 0.0249277]
-    >>> # theorectical uncertainty
+
+    # theorectical uncertainty
     >>> print(np.sqrt(0.528678304239 * (1 - 0.528678304239) / 401))
     0.0249277036876
     """
@@ -596,21 +639,27 @@ class BernoulliGaussianMixtureLikelihood(Likelihood):
     Examples
     --------
     >>> import numpy as np
-    >>> from oktopus import BernoulliGaussianMixtureLikelihood, UniformPrior, Posterior
+    >>> from oktopus import (BernoulliGaussianMixtureLikelihood,
+                             UniformPrior, Posterior)
     >>> from oktopus.models import ConstantModel as constant
-    >>> # generate integer fake data in the set {0, 1}
+
+    # generate integer fake data in the set {0, 1}
     >>> np.random.seed(0)
     >>> y = np.append(np.random.normal(size=30), 1+np.random.normal(size=70))
-    >>> # create a model
+
+    # create a model
     >>> p = constant()
-    >>> # build likelihood
+
+    # build likelihood
     >>> ll = BernoulliGaussianMixtureLikelihood(data=y, mean=p, var=1.)
     >>> unif = UniformPrior(lb=0., ub=1.)
     >>> pp = Posterior(likelihood=ll, prior=unif)
     >>> result = pp.fit(x0=.3, method='powell')
-    >>> # get best fit parameters
+
+    # get best fit parameters
     >>> print(np.round(result.x, 3))
     0.803
+
     >>> print(np.mean(y>0)) # theorectical MLE
     0.78
     """

--- a/oktopus/loss.py
+++ b/oktopus/loss.py
@@ -44,9 +44,11 @@ class LossFunction(object):
 
     def fit(self, optimizer='minimize', **kwargs):
         """
-        Minimizes the :func:`evaluate` function using :func:`scipy.optimize.minimize`,
-        :func:`scipy.optimize.differential_evolution`,
-        :func:`scipy.optimize.basinhopping`, or :func:`skopt.gp.gp_minimize`.
+        Minimizes the :func:`evaluate` function using 
+            :func:`scipy.optimize.minimize`,
+            :func:`scipy.optimize.differential_evolution`,
+            :func:`scipy.optimize.basinhopping`, or 
+            :func:`skopt.gp.gp_minimize`.
 
         Parameters
         ----------
@@ -55,17 +57,18 @@ class LossFunction(object):
 
                 - ``'minimize'`` uses :func:`scipy.optimize.minimize`
 
-                - ``'differential_evolution'`` uses :func:`scipy.optimize.differential_evolution`
+                - ``'differential_evolution'`` uses 
+                    :func:`scipy.optimize.differential_evolution`
 
                 - ``'basinhopping'`` uses :func:`scipy.optimize.basinhopping`
 
                 - ``'gp_minimize'`` uses :func:`skopt.gp.gp_minimize`
 
             `'minimize'` is usually robust enough and therefore recommended
-            whenever a good initial guess can be provided. The remaining options
-            are global optimizers which might provide better results precisely
-            in cases where a close engouh initial guess cannot be obtained
-            trivially.
+            whenever a good initial guess can be provided.
+            The remaining options are global optimizers which might provide 
+            better results precisely in cases where a close engouh initial 
+            guess cannot be obtained trivially.
         kwargs : dict
             Dictionary for additional arguments.
 
@@ -156,8 +159,10 @@ class L1Norm(LossFunction):
             self._evaluate = self._evaluate_w_regularization
 
     def __repr__(self):
-        return "<L1Norm(data={}, model={}, regularization={})>".format(self.data,
-                self.model, self.regularization)
+        return (f"<L1Norm("
+                f"data={self.data}, "
+                f"model={self.model}, "
+                f"regularization={self.regularization})>")
 
     @property
     def regularization(self):
@@ -173,12 +178,11 @@ class L1Norm(LossFunction):
             self._evaluate = self._evaluate_wo_regularization
 
     def _evaluate_wo_regularization(self, *params):
-        return  np.nansum(np.absolute(self.data - self.model(*params)))
+        return np.nansum(np.absolute(self.data - self.model(*params)))
 
     def _evaluate_w_regularization(self, *params):
-        return  np.nansum(np.absolute(self.data - self.model(*params[:-1]))
-                          + params[-1] * self.regularization(*params[:-1]))
+        return np.nansum(np.absolute(self.data - self.model(*params[:-1]))
+                         + params[-1] * self.regularization(*params[:-1]))
 
     def evaluate(self, params):
         return self._evaluate(*params)
-

--- a/oktopus/models.py
+++ b/oktopus/models.py
@@ -5,6 +5,7 @@ import math
 
 
 class Model(object):
+
     def __call__(self, *params):
         return self.evaluate(*params)
 
@@ -14,6 +15,7 @@ class Model(object):
 
 
 class ConstantModel(Model):
+
     def evaluate(self, c):
         return np.array([c])
 
@@ -22,6 +24,7 @@ class ConstantModel(Model):
 
 
 class LinearModel(Model):
+
     def __init__(self, X):
         self.X = np.asarray(X)
 
@@ -42,15 +45,18 @@ class LinearModel(Model):
 
 
 class SymmetricGaussian2D(Model):
+
     def __init__(self, x, y):
         self.x = x
         self.y = y
 
     def evaluate(self, A, xo, yo, s):
-        return A * np.exp(-0.5 * (((self.x - xo) ** 2 + (self.y - yo) ** 2)) / s ** 2)
+        return A * np.exp(-0.5 * (((self.x - xo) ** 2 +
+                                   (self.y - yo) ** 2)) / s ** 2)
 
 
 class Gaussian2D(Model):
+
     def __init__(self, x, y):
         self.x = x
         self.y = y
@@ -62,6 +68,7 @@ class Gaussian2D(Model):
 
 
 class Gaussian2DPlusBkg(Gaussian2D):
+
     def __init__(self, x, y):
         super(Gaussian2DPlusBkg, self).__init__(x, y)
 
@@ -70,6 +77,7 @@ class Gaussian2DPlusBkg(Gaussian2D):
 
 
 class IntegratedSymmetricGaussian2D(Model):
+
     def __init__(self, x, y):
         self.x = x
         self.y = y
@@ -83,6 +91,7 @@ class IntegratedSymmetricGaussian2D(Model):
 
 
 class ExpSquaredKernel(Model):
+
     def __init__(self, t):
         self.t = t
 
@@ -91,6 +100,7 @@ class ExpSquaredKernel(Model):
 
 
 class WhiteNoiseKernel(Model):
+
     def __init__(self, n):
         self.n = n
 

--- a/oktopus/posterior.py
+++ b/oktopus/posterior.py
@@ -1,9 +1,12 @@
 import autograd.numpy as np
 from .loss import LossFunction
-from .likelihood import PoissonLikelihood, GaussianLikelihood, MultivariateGaussianLikelihood
+from .likelihood import (PoissonLikelihood,
+                         GaussianLikelihood,
+                         MultivariateGaussianLikelihood)
 
 
-__all__ = ['Posterior', 'GaussianPosterior', 'PoissonPosterior', 'MultivariateGaussianPosterior']
+__all__ = ['Posterior', 'GaussianPosterior',
+           'PoissonPosterior', 'MultivariateGaussianPosterior']
 
 
 class Posterior(LossFunction):
@@ -41,8 +44,9 @@ class Posterior(LossFunction):
         self.logprior = prior
 
     def __repr__(self):
-        return "<Posterior(likelihood={}, prior={})>".format(self.loglikelihood,
-                self.prior)
+        return ("<Posterior("
+                f"likelihood={self.loglikelihood}, "
+                f"prior={self.logprior})>")
 
     def evaluate(self, params):
         """Evaluates the negative of the log of the posterior at params.
@@ -60,7 +64,8 @@ class Posterior(LossFunction):
         return self.loglikelihood(params) + self.logprior(params)
 
     def gradient(self, params):
-        """Evaluates the gradient of the negative of the log of the posterior at params.
+        """Evaluates the gradient of the negative of the log of the 
+            posterior at params.
 
         Parameters
         ----------
@@ -72,7 +77,8 @@ class Posterior(LossFunction):
         value : scalar
             Value of the negative of the log of the posterior at params
         """
-        return self.loglikelihood.gradient(params) + self.logprior.gradient(params)
+        return (self.loglikelihood.gradient(params) +
+                self.logprior.gradient(params))
 
 
 class GaussianPosterior(Posterior):
@@ -95,7 +101,8 @@ class GaussianPosterior(Posterior):
 
     Examples
     --------
-    >>> from oktopus import GaussianPosterior, GaussianPrior, UniformPrior, JointPrior
+    >>> from oktopus import (GaussianPosterior, GaussianPrior,
+                             UniformPrior, JointPrior)
     >>> import autograd.numpy as np
     >>> #from matplotlib import pyplot as plt
     >>> x = np.linspace(0, 10, 200)
@@ -107,16 +114,21 @@ class GaussianPosterior(Posterior):
     >>> slope_prior = UniformPrior(lb=1., ub=10.)
     >>> intercept_prior = UniformPrior(lb=5., ub=20.)
     >>> joint_prior = JointPrior(slope_prior, intercept_prior)
-    >>> logP = GaussianPosterior(data=fake_data, mean=my_line, var=4, prior=joint_prior)
+    >>> logP = GaussianPosterior(data=fake_data,
+                                 mean=my_line,
+                                 var=4,
+                                 prior=joint_prior)
     >>> p0 = (slope_prior.mean, intercept_prior.mean) # initial guesses for slope and intercept
     >>> p_hat = logP.fit(x0=p0, method='powell')
     >>> p_hat.x # fitted parameters
     array([  2.96264088,  10.3286166 ])
-    >>> #plt.plot(x, fake_data, 'o')
-    >>> #plt.plot(x, line(*p_hat.x))
+    >>> # plt.plot(x, fake_data, 'o')
+    >>> # plt.plot(x, line(*p_hat.x))
     >>> # The exact values from linear algebra are:
     >>> M = np.array([[np.sum(x * x), np.sum(x)], [np.sum(x), len(x)]])
-    >>> slope, intercept = np.dot(np.linalg.inv(M), np.array([np.sum(fake_data * x), np.sum(fake_data)]))
+    >>> slope, intercept = np.dot(np.linalg.inv(M),
+                                  np.array([np.sum(fake_data * x),
+                                  np.sum(fake_data)]))
     >>> print(slope)
     2.96264087528
     >>> print(intercept)
@@ -130,8 +142,11 @@ class GaussianPosterior(Posterior):
         self.loglikelihood = GaussianLikelihood(data, mean, var)
 
     def __repr__(self):
-        return "<GaussianPosterior(data={}, mean={}, var={}, prior={})>".format(self.data,
-                self.mean, self.var, self.prior)
+        return (f"<GaussianPosterior("
+                f"data={self.data}, "
+                f"mean={self.mean}, "
+                f"var={self.var}, "
+                f"prior={self.logprior})>")
 
 
 class PoissonPosterior(Posterior):
@@ -161,11 +176,13 @@ class PoissonPosterior(Posterior):
     >>> toy_data = np.random.randint(1, 20, size=100)
     >>> def mean(l):
     ...     return np.array([l])
-    >>> logP = PoissonPosterior(data=toy_data, mean=mean, prior=UniformPrior(lb=1., ub=20.))
+    >>> logP = PoissonPosterior(data=toy_data, mean=mean,
+                                prior=UniformPrior(lb=1., ub=20.))
     >>> mean_hat = logP.fit(x0=10.5)
     >>> mean_hat.x # MAP is the same of MLE for uniform prior
     array([ 9.29000013])
-    >>> logP = PoissonPosterior(data=toy_data, mean=mean, prior=GaussianPrior(mean=10, var=4))
+    >>> logP = PoissonPosterior(data=toy_data, mean=mean,
+                                prior=GaussianPrior(mean=10, var=4))
     >>> mean_hat = logP.fit(x0=10.5)
     >>> mean_hat.x
     array([ 9.30614261])
@@ -178,13 +195,16 @@ class PoissonPosterior(Posterior):
         self.loglikelihood = PoissonLikelihood(data, mean)
 
     def __repr__(self):
-        return "<PoissonPosterior(data={}, mean={}, prior={})>".format(self.data,
-                self.mean, self.prior)
+        return ("<PoissonPosterior("
+                f"data={self.data}, "
+                f"mean={self.mean}, "
+                f"prior={self.logprior})>")
 
 
 class MultivariateGaussianPosterior(Posterior):
     """
-    Implements the posterior distribution for a multivariate gaussian distribution.
+    Implements the posterior distribution for a
+        multivariate gaussian distribution.
 
     Attributes
     ----------
@@ -208,8 +228,11 @@ class MultivariateGaussianPosterior(Posterior):
         self.cov = cov
         self.dim = dim
         self.logprior = prior
-        self.loglikelihood = MultivariateGaussianLikelihood(data, mean, cov, dim)
+        self.loglikelihood = MultivariateGaussianLikelihood(
+            data, mean, cov, dim)
 
     def __repr__(self):
-        return ("<MultivariateGaussianPosterior(mean={}, cov={},"
-                " prior={})>".format(self.mean, self.cov, self.prior))
+        return ("<MultivariateGaussianPosterior("
+                f"mean={self.mean}, "
+                f"cov={self.cov}, "
+                f"prior={self.logprior})>")

--- a/oktopus/prior.py
+++ b/oktopus/prior.py
@@ -3,7 +3,8 @@ import autograd.numpy as np
 from .loss import LossFunction
 
 
-__all__ = ['Prior', 'JointPrior', 'UniformPrior', 'GaussianPrior', 'LaplacianPrior']
+__all__ = ['Prior', 'JointPrior', 'UniformPrior',
+           'GaussianPrior', 'LaplacianPrior']
 
 
 class Prior(LossFunction):
@@ -65,7 +66,7 @@ class JointPrior(Prior):
         self.components = args
 
     def __repr__(self):
-        return "<JointPrior({})>".format([c.__repr__() for c in self.components])
+        return f"<JointPrior({[c.__repr__() for c in self.components]})>"
 
     def evaluate(self, params):
         """Computes the sum of the log of each distribution given in *args*
@@ -81,7 +82,8 @@ class JointPrior(Prior):
         Returns
         -------
         value : scalar
-            Sum of the negative of the log of each distribution given in **args**
+            Sum of the negative of the log of each distribution
+                given in **args**
         """
         p = 0
         for i in range(len(params)):
@@ -112,7 +114,8 @@ class JointPrior(Prior):
 
     @property
     def mean(self):
-        return np.concatenate([self.components[i].mean for i in range(len(self.components))])
+        return np.concatenate([self.components[i].mean
+                               for i in range(len(self.components))])
 
 
 class UniformPrior(Prior):
@@ -140,11 +143,12 @@ class UniformPrior(Prior):
         self.lb = np.asarray([lb]).reshape(-1)
         self.ub = np.asarray([ub]).reshape(-1)
         if (self.lb >= self.ub).any():
-            raise ValueError("The lower bounds should be smaller than the upper bounds.")
+            raise ValueError(
+                "The lower bounds should be smaller than the upper bounds.")
         self.name = name
 
     def __repr__(self):
-        return "<UniformPrior(lb={}, ub={})>".format(self.lb, self.ub)
+        return f"<UniformPrior(lb={self.lb}, ub={self.ub})>"
 
     @property
     def mean(self):
@@ -194,7 +198,7 @@ class GaussianPrior(Prior):
         self.name = name
 
     def __repr__(self):
-        return "<GaussianPrior(mean={}, var={})>".format(self.mean, self.var)
+        return f"<GaussianPrior(mean={self.mean}, var={self.var})>"
 
     @property
     def mean(self):
@@ -213,6 +217,7 @@ class GaussianPrior(Prior):
 
     def gradient(self, params):
         return ((params - self.mean) / self.var).sum()
+
 
 class LaplacianPrior(Prior):
     """Computes the negative log pdf for a n-dimensional independent Laplacian
@@ -239,7 +244,7 @@ class LaplacianPrior(Prior):
         self.name = name
 
     def __repr__(self):
-        return "<LaplacianPrior(mean={}, var={})>".format(self.mean, self.var)
+        return f"<LaplacianPrior(mean={self.mean}, var={self.var})>"
 
     @property
     def mean(self):


### PR DESCRIPTION
I was trying to run the 3 examples given on the tutorial page; but they would process because `self.prior` does not exist.

So I edited the code to change `self.prior` to `self.logprior`, which does exist. I then realized that `UniformPrior` and `GaussianPrior` are actually "log priors" themselves.

While editing the code, to make it readable on my `Sublime`, I had to adjust for PEP8 compliance -- I use AutoPEP8 with Sublime, so a lot of it was automated.

I hope that this helps. The example now runs; but the results are not the same as on the docs pages. I think that the boundaries are mismatched.